### PR TITLE
[CES-564] Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,33 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    uses: pagopa/dx/.github/workflows/release.yaml@25089e9d07bb86b79a2c7ed7a235534a691c6817
     name: Release
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # https://github.com/actions/checkout/issues/1471#issuecomment-1771231294
+          fetch-tags: true
+          fetch-depth: 0
+      # Corepack is an official tool by Node.js that manages package managers versions
+      - name: Setup yarn
+        run: corepack enable
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308 # v1.4.9
+        with:
+          version: yarn run version
+          publish: yarn run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}


### PR DESCRIPTION
Replace `release.yaml` workflow with the one coming from the `dx` repository, because the referenced workflow is not callable.