### PR TITLE
[CES-579] Rename secret to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,4 +42,4 @@ jobs:
           version: yarn run version
           publish: yarn run release
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Rename `BOT_GH_TOKEN` to `GITHUB_TOKEN` to let the workflow work.

If we are going to start the release of any application starting the creation of the tag, then we will change the token accordingly.
At the moment the `GITHUB_TOKEN` is enough.