### PR TITLE
Fix turbo configuration file key names

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "globalDependencies": [
     "**/.env.*local"
   ],
-  "pipeline": {
+  "tasks": {
     "build": {
       "inputs": [
         "src/**/*.ts",
@@ -48,7 +48,7 @@
       "inputs": [
         "src/**/*.ts"
       ],
-      "outputMode": "errors-only",
+      "outputLogs": "errors-only",
       "dependsOn": [
         "^test",
         "^build"
@@ -58,7 +58,7 @@
       "inputs": [
         "src/**/*.ts"
       ],
-      "outputMode": "errors-only",
+      "outputLogs": "errors-only",
       "dependsOn": [
         "^test",
         "^build"


### PR DESCRIPTION
Version 2 of turbo made some breaking changes also in the configuration file `turbo.json`.

Fix the syntax of that file.