### PR TITLE
[CES-632] Use GitHub Bot token to checkout repository and to create a new release

### DIFF
--- a/.changeset/gold-cars-hear.md
+++ b/.changeset/gold-cars-hear.md
@@ -1,0 +1,5 @@
+---
+"@infra/repository": minor
+---
+
+Add new repository secret

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
           # https://github.com/actions/checkout/issues/1471#issuecomment-1771231294
           fetch-tags: true
           fetch-depth: 0
+          token: ${{ secrets.GH_BOT_PAT }}
+
       # Corepack is an official tool by Node.js that manages package managers versions
       - name: Setup yarn
         run: corepack enable
@@ -41,5 +43,6 @@ jobs:
         with:
           version: yarn run version
           publish: yarn run release
+          setupGitUser: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_PAT }}

--- a/infra/repository/README.md
+++ b/infra/repository/README.md
@@ -34,6 +34,8 @@ No modules.
 | [github_repository_environment.github_repository_environment_dev_cd](https://registry.terraform.io/providers/integrations/github/6.4.0/docs/resources/repository_environment) | resource |
 | [github_repository_environment.github_repository_environment_dev_ci](https://registry.terraform.io/providers/integrations/github/6.4.0/docs/resources/repository_environment) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.github_bot_pat](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_user_assigned_identity.identity_dev_cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [azurerm_user_assigned_identity.identity_dev_ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |

--- a/infra/repository/data.tf
+++ b/infra/repository/data.tf
@@ -19,6 +19,6 @@ data "azurerm_key_vault" "common" {
 }
 
 data "azurerm_key_vault_secret" "github_bot_pat" {
-  name         = "github-runner-pat"
+  name         = "dx-pagopa-bot-pat"
   key_vault_id = data.azurerm_key_vault.common.id
 }

--- a/infra/repository/data.tf
+++ b/infra/repository/data.tf
@@ -12,3 +12,13 @@ data "github_organization_teams" "all" {
   root_teams_only = true
   summary_only    = true
 }
+
+data "azurerm_key_vault" "common" {
+  name                = "${local.project}-${local.location_short}-common-kv-${local.suffix}"
+  resource_group_name = "${local.project}-${local.location_short}-common-rg-${local.suffix}"
+}
+
+data "azurerm_key_vault_secret" "github_bot_pat" {
+  name         = "github-runner-pat"
+  key_vault_id = data.azurerm_key_vault.common.id
+}

--- a/infra/repository/locals.tf
+++ b/infra/repository/locals.tf
@@ -1,11 +1,14 @@
 locals {
-  project = "dx-d"
+  project        = "dx-d"
+  suffix         = "01"
+  location_short = "itn"
 
   identity_resource_group_name = "${local.project}-identity-rg"
 
   repo_secrets = {
     "ARM_TENANT_ID"       = data.azurerm_client_config.current.tenant_id,
     "ARM_SUBSCRIPTION_ID" = data.azurerm_subscription.current.subscription_id
+    "GH_BOT_PAT"          = data.azurerm_key_vault_secret.github_bot_pat.value
   }
 
   ci = {


### PR DESCRIPTION
Create a new repository secret, called `GH_BOT_PAT`.

Use the branch new `GH_BOT_PAT` as GitHub token for the release workflow.
Doing this, we should allow a workflow (the one that creates the release and push some tags) to trigger another workflow (the one that will make the deploy).

> [!NOTE]
> According to [this comment in an issue](https://github.com/changesets/action/issues/187#issuecomment-2317070874), this PR can been enough.
> In case the changes in this PR do not make it possible to trigger a different workflow from a workflow, then we should also add also the changes introduced in [this PR](https://github.com/pagopa/trial-system/pull/204).