### PR TITLE
[CES-645] Add `GET task/{id}`

### DIFF
--- a/.changeset/large-needles-hide.md
+++ b/.changeset/large-needles-hide.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": minor
+---
+
+Update APIM OpenAPI specification

--- a/.changeset/yellow-hats-worry.md
+++ b/.changeset/yellow-hats-worry.md
@@ -1,0 +1,5 @@
+---
+"to-do-api": minor
+---
+
+[CES-645] Add `GET task/{id}`

--- a/apps/to-do-api/docs/openapi.yaml
+++ b/apps/to-do-api/docs/openapi.yaml
@@ -62,6 +62,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProblemJSON'
 
+  /tasks/{taskId}:
+    get:
+      description: Get information of a task
+      summary: Get a task
+      operationId: getTaskById
+      parameters:
+        - in: path
+          name: taskId
+          schema:
+            type: string
+          required: true
+          description: The id of the task
+      responses:
+        '200':
+          description: Details of the task
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskItem'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJSON'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJSON'
+
 components:
   schemas:
     ApplicationInfo:

--- a/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
+++ b/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
@@ -1,16 +1,39 @@
-import { Container } from "@azure/cosmos";
+import { Container, ItemDefinition, ItemResponse } from "@azure/cosmos";
 import * as E from "fp-ts/lib/Either.js";
 import * as O from "fp-ts/lib/Option.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { pipe } from "fp-ts/lib/function.js";
+import * as t from "io-ts";
 
 import { TaskCodec } from "../../../domain/Task.js";
 import { TaskRepository } from "../../../domain/TaskRepository.js";
 import { decodeFromFeed } from "./decode.js";
 import { cosmosErrorToDomainError } from "./errors.js";
 
+// TODO: Move this to a separate file (introduced in another PR)
+export const decodeFromItem =
+  <A, O>(codec: t.Type<A, O>) =>
+  <T extends ItemDefinition>(item: ItemResponse<T>) =>
+    pipe(
+      O.fromNullable(item.resource),
+      O.map(codec.decode),
+      // transform Option<Either<L, R>> => Either<L, Option<R>>
+      O.sequence(E.Applicative),
+      E.mapLeft(
+        () =>
+          new Error(
+            `Unable to parse the ${item.resource?.id} using codec ${codec.name}`,
+          ),
+      ),
+    );
+
 export const makeTaskRepository = (container: Container): TaskRepository => ({
-  get: () => TE.right(O.none),
+  get: (id) =>
+    pipe(
+      TE.tryCatch(() => container.item(id, id).read(), E.toError),
+      TE.flatMapEither(decodeFromItem(TaskCodec)),
+      TE.mapLeft(cosmosErrorToDomainError),
+    ),
   insert: (task) =>
     pipe(
       TE.tryCatch(() => container.items.create(task), E.toError),

--- a/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
+++ b/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
@@ -1,5 +1,6 @@
 import { Container } from "@azure/cosmos";
 import * as E from "fp-ts/lib/Either.js";
+import * as O from "fp-ts/lib/Option.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { pipe } from "fp-ts/lib/function.js";
 
@@ -9,6 +10,7 @@ import { decodeFromFeed } from "./decode.js";
 import { cosmosErrorToDomainError } from "./errors.js";
 
 export const makeTaskRepository = (container: Container): TaskRepository => ({
+  get: () => TE.right(O.none),
   insert: (task) =>
     pipe(
       TE.tryCatch(() => container.items.create(task), E.toError),

--- a/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
+++ b/apps/to-do-api/src/adapters/azure/cosmosdb/TaskRepository.ts
@@ -1,31 +1,12 @@
-import { Container, ItemDefinition, ItemResponse } from "@azure/cosmos";
+import { Container } from "@azure/cosmos";
 import * as E from "fp-ts/lib/Either.js";
-import * as O from "fp-ts/lib/Option.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { pipe } from "fp-ts/lib/function.js";
-import * as t from "io-ts";
 
 import { TaskCodec } from "../../../domain/Task.js";
 import { TaskRepository } from "../../../domain/TaskRepository.js";
-import { decodeFromFeed } from "./decode.js";
+import { decodeFromFeed, decodeFromItem } from "./decode.js";
 import { cosmosErrorToDomainError } from "./errors.js";
-
-// TODO: Move this to a separate file (introduced in another PR)
-export const decodeFromItem =
-  <A, O>(codec: t.Type<A, O>) =>
-  <T extends ItemDefinition>(item: ItemResponse<T>) =>
-    pipe(
-      O.fromNullable(item.resource),
-      O.map(codec.decode),
-      // transform Option<Either<L, R>> => Either<L, Option<R>>
-      O.sequence(E.Applicative),
-      E.mapLeft(
-        () =>
-          new Error(
-            `Unable to parse the ${item.resource?.id} using codec ${codec.name}`,
-          ),
-      ),
-    );
 
 export const makeTaskRepository = (container: Container): TaskRepository => ({
   get: (id) =>

--- a/apps/to-do-api/src/adapters/azure/cosmosdb/__tests__/mocks.ts
+++ b/apps/to-do-api/src/adapters/azure/cosmosdb/__tests__/mocks.ts
@@ -2,6 +2,7 @@ import { mock, mockFn } from "vitest-mock-extended";
 
 export const makeContainerMock = () =>
   mock({
+    item: mockFn(),
     items: {
       create: mockFn(),
       query: mockFn(),

--- a/apps/to-do-api/src/adapters/azure/cosmosdb/decode.ts
+++ b/apps/to-do-api/src/adapters/azure/cosmosdb/decode.ts
@@ -1,4 +1,5 @@
-import { FeedResponse } from "@azure/cosmos";
+import { FeedResponse, ItemDefinition, ItemResponse } from "@azure/cosmos";
+import * as O from "fp-ts/Option";
 import * as E from "fp-ts/lib/Either.js";
 import { pipe } from "fp-ts/lib/function.js";
 import * as t from "io-ts";
@@ -17,5 +18,25 @@ export const decodeFromFeed =
       E.mapLeft(
         () =>
           new Error(`Unable to parse the resources using codec ${codec.name}`),
+      ),
+    );
+
+/**
+ * Decode a single resource, extracted from an ItemResponse, using a codec.
+ * @param codec the io-ts codec to use to decode the resource
+ */
+export const decodeFromItem =
+  <A, O>(codec: t.Type<A, O>) =>
+  <T extends ItemDefinition>(item: ItemResponse<T>) =>
+    pipe(
+      O.fromNullable(item.resource),
+      O.map(codec.decode),
+      // transform Option<Either<L, R>> => Either<L, Option<R>>
+      O.sequence(E.Applicative),
+      E.mapLeft(
+        () =>
+          new Error(
+            `Unable to parse the ${item.resource?.id} using codec ${codec.name}`,
+          ),
       ),
     );

--- a/apps/to-do-api/src/adapters/azure/functions/get-task.ts
+++ b/apps/to-do-api/src/adapters/azure/functions/get-task.ts
@@ -1,0 +1,36 @@
+import * as H from "@pagopa/handler-kit";
+import { httpAzureFunction } from "@pagopa/handler-kit-azure-func";
+import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
+import { flow, pipe } from "fp-ts/lib/function.js";
+
+import { Capabilities } from "../../../domain/Capabilities.js";
+import { TaskIdCodec } from "../../../domain/Task.js";
+import { TaskItem } from "../../../generated/definitions/internal/TaskItem.js";
+import { getTaskById } from "../../../use-cases/get-task.js";
+import { toHttpProblemJson, toTaskItemAPI } from "../../http/codec.js";
+import { parsePathParameter } from "../../http/middleware.js";
+
+type Env = Pick<Capabilities, "taskIdGenerator" | "taskRepository">;
+
+const makeHandlerKitHandler: H.Handler<
+  H.HttpRequest,
+  | H.HttpResponse<H.ProblemJson, H.HttpErrorStatusCode>
+  | H.HttpResponse<TaskItem>,
+  Env
+> = H.of((req: H.HttpRequest) =>
+  pipe(
+    RTE.ask<Env>(),
+    // validate and extract path parameter
+    RTE.apSW(
+      "id",
+      RTE.fromEither(parsePathParameter(TaskIdCodec, "taskId")(req)),
+    ),
+    // execute use case
+    RTE.flatMap(({ id }) => getTaskById(id)),
+    // handle result and prepare response
+    RTE.mapBoth(toHttpProblemJson, flow(toTaskItemAPI, H.successJson)),
+    RTE.orElseW(RTE.of),
+  ),
+);
+
+export const makeGetTaskHandler = httpAzureFunction(makeHandlerKitHandler);

--- a/apps/to-do-api/src/adapters/http/middleware.ts
+++ b/apps/to-do-api/src/adapters/http/middleware.ts
@@ -19,3 +19,15 @@ export const parseRequestBody =
       H.parse(schema),
       E.mapLeft(() => new H.HttpBadRequestError("Missing or invalid body")),
     );
+
+/**
+ * Parses a specific path parameter of an HTTP request using the provided schema.
+ */
+export const parsePathParameter =
+  <T>(schema: Decoder<unknown, T>, paramName: string) =>
+  (req: H.HttpRequest) =>
+    pipe(
+      req.path[paramName],
+      H.parse(schema, `Invalid format of ${paramName} parameter`),
+      E.mapLeft(({ message }) => new H.HttpBadRequestError(message)),
+    );

--- a/apps/to-do-api/src/domain/TaskRepository.ts
+++ b/apps/to-do-api/src/domain/TaskRepository.ts
@@ -1,3 +1,4 @@
+import * as O from "fp-ts/lib/Option.js";
 import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { pipe } from "fp-ts/lib/function.js";
@@ -6,9 +7,16 @@ import { Capabilities } from "./Capabilities.js";
 import { Task } from "./Task.js";
 
 export interface TaskRepository {
+  get: (id: Task["id"]) => TE.TaskEither<Error, O.Option<Task>>;
   insert: (task: Task) => TE.TaskEither<Error, Task>;
   list: () => TE.TaskEither<Error, readonly Task[]>;
 }
+
+export const getTask = (id: Task["id"]) =>
+  pipe(
+    RTE.ask<Pick<Capabilities, "taskRepository">>(),
+    RTE.flatMapTaskEither(({ taskRepository }) => taskRepository.get(id)),
+  );
 
 export const insertTask = (task: Task) =>
   pipe(

--- a/apps/to-do-api/src/main.ts
+++ b/apps/to-do-api/src/main.ts
@@ -46,6 +46,13 @@ app.http("createTask", {
   route: "tasks",
 });
 
+app.http("getTaskById", {
+  authLevel: "function",
+  handler: makeGetTaskHandler(env),
+  methods: ["GET"],
+  route: "tasks/{taskId}",
+});
+
 app.http("getTask", {
   authLevel: "function",
   handler: makeGetTasksHandler(env),

--- a/apps/to-do-api/src/main.ts
+++ b/apps/to-do-api/src/main.ts
@@ -6,6 +6,7 @@ import { pipe } from "fp-ts/lib/function.js";
 
 import { makeTaskRepository } from "./adapters/azure/cosmosdb/TaskRepository.js";
 import { makePostTaskHandler } from "./adapters/azure/functions/create-task.js";
+import { makeGetTaskHandler } from "./adapters/azure/functions/get-task.js";
 import { makeGetTasksHandler } from "./adapters/azure/functions/get-tasks.js";
 import { makeInfoHandler } from "./adapters/azure/functions/info.js";
 import { makeTaskIdGenerator } from "./adapters/ulid/id-generator.js";

--- a/apps/to-do-api/src/use-cases/__tests__/get-task.test.ts
+++ b/apps/to-do-api/src/use-cases/__tests__/get-task.test.ts
@@ -1,0 +1,32 @@
+import * as E from "fp-ts/lib/Either.js";
+import * as O from "fp-ts/lib/Option.js";
+import * as TE from "fp-ts/lib/TaskEither.js";
+import { describe, expect, it } from "vitest";
+
+import { aTask, makeTestEnvironment } from "../../domain/__tests__/data.js";
+import { ItemNotFound } from "../../domain/errors.js";
+import { getTaskById } from "../get-task.js";
+
+describe("getTask", () => {
+  const { id } = aTask;
+  it("should return the desired task", async () => {
+    const env = makeTestEnvironment();
+
+    env.taskRepository.get.mockReturnValueOnce(TE.right(O.some(aTask)));
+
+    const actual = await getTaskById(id)(env)();
+    expect(actual).toStrictEqual(E.right(aTask));
+    expect(env.taskRepository.get).toHaveBeenCalledWith(id);
+  });
+
+  it("should return ItemNotFound error", async () => {
+    const env = makeTestEnvironment();
+
+    const error = new ItemNotFound("Task not found");
+
+    env.taskRepository.get.mockReturnValueOnce(TE.right(O.none));
+    const actual = await getTaskById(id)(env)();
+
+    expect(actual).toStrictEqual(E.left(error));
+  });
+});

--- a/apps/to-do-api/src/use-cases/get-task.ts
+++ b/apps/to-do-api/src/use-cases/get-task.ts
@@ -8,6 +8,7 @@ import { ItemNotFound } from "../domain/errors.js";
 export const getTaskById = (id: Task["id"]) =>
   pipe(
     getTask(id),
+    // Handle the Option
     RTE.flatMapOption(
       (some) => some,
       () => new ItemNotFound("Task not found"),

--- a/apps/to-do-api/src/use-cases/get-task.ts
+++ b/apps/to-do-api/src/use-cases/get-task.ts
@@ -1,0 +1,15 @@
+import * as RTE from "fp-ts/lib/ReaderTaskEither.js";
+import { pipe } from "fp-ts/lib/function.js";
+
+import { Task } from "../domain/Task.js";
+import { getTask } from "../domain/TaskRepository.js";
+import { ItemNotFound } from "../domain/errors.js";
+
+export const getTaskById = (id: Task["id"]) =>
+  pipe(
+    getTask(id),
+    RTE.flatMapOption(
+      (some) => some,
+      () => new ItemNotFound("Task not found"),
+    ),
+  );

--- a/apps/to-do-api/src/use-cases/get-task.ts
+++ b/apps/to-do-api/src/use-cases/get-task.ts
@@ -9,8 +9,5 @@ export const getTaskById = (id: Task["id"]) =>
   pipe(
     getTask(id),
     // Handle the Option
-    RTE.flatMapOption(
-      (some) => some,
-      () => new ItemNotFound("Task not found"),
-    ),
+    RTE.flatMap(RTE.fromOption(() => new ItemNotFound("Task not found"))),
   );


### PR DESCRIPTION
Add `GET /tasks/{id}` to OpenAPI spec

Implements the adapters to get a task by its id.