### PR TITLE
[CES-674] Add app service permission to read secrets from key vault

### DIFF
--- a/.changeset/smooth-mayflies-compare.md
+++ b/.changeset/smooth-mayflies-compare.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+[CES-674] Add app service permission to read secrets from key vault

--- a/infra/resources/dev/app_service.tf
+++ b/infra/resources/dev/app_service.tf
@@ -40,4 +40,12 @@ module "app_service_roles" {
       resource_group_name = module.apim.resource_group_name
       role                = "reader"
   }]
+
+  key_vault = [{
+    name                = data.azurerm_key_vault.common_kv.name
+    resource_group_name = data.azurerm_key_vault.common_kv.resource_group_name
+    roles = {
+      secrets = "reader"
+    }
+  }]
 }


### PR DESCRIPTION
Add app service permission to read secrets from key vault

> [!IMPORTANT]
> This is required to add the API key as the environment variable of the app service, without leaking sensitive information.