### PR TITLE
[CES-675] Add API_KEY as environment variable

### DIFF
--- a/.changeset/friendly-shrimps-divide.md
+++ b/.changeset/friendly-shrimps-divide.md
@@ -1,0 +1,6 @@
+---
+"@infra/resources": patch
+---
+
+[CES-675] Add API_KEY as environment variable
+Use the approach explained in [Azure documentation here](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli)

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -49,6 +49,7 @@
 | [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [azurerm_eventhub_authorization_rule.auth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_key_vault.common_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault_secret.apim_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.logs_token](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.target_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.to_do_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/infra/resources/dev/app_service.tf
+++ b/infra/resources/dev/app_service.tf
@@ -2,6 +2,7 @@ locals {
   to_do_webapp_settings = {
     API_BASE_URL  = module.apim.gateway_url
     API_BASE_PATH = "todo"
+    API_KEY       = "@Microsoft.KeyVault(SecretUri=\"${data.azurerm_key_vault_secret.apim_api_key.versionless_id}\")"
   }
 }
 

--- a/infra/resources/dev/app_service.tf
+++ b/infra/resources/dev/app_service.tf
@@ -2,7 +2,7 @@ locals {
   to_do_webapp_settings = {
     API_BASE_URL  = module.apim.gateway_url
     API_BASE_PATH = "todo"
-    API_KEY       = "@Microsoft.KeyVault(SecretUri=\"${data.azurerm_key_vault_secret.apim_api_key.versionless_id}\")"
+    API_KEY       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault_secret.apim_api_key.versionless_id})"
   }
 }
 

--- a/infra/resources/dev/data.tf
+++ b/infra/resources/dev/data.tf
@@ -30,3 +30,8 @@ data "azurerm_key_vault_secret" "to_do_api_key" {
   key_vault_id = data.azurerm_key_vault.common_kv.id
   name         = "to-do-api-key"
 }
+
+data "azurerm_key_vault_secret" "apim_api_key" {
+  key_vault_id = data.azurerm_key_vault.common_kv.id
+  name         = "playground-apim-test-key"
+}


### PR DESCRIPTION
Add `API_KEY` environment variable to the app service, referencing the value from the key vault, using this approach: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references?tabs=azure-cli