### PR TITLE
fix: package name for test-durable-function

### DIFF
--- a/.changeset/silly-kiwis-rush.md
+++ b/.changeset/silly-kiwis-rush.md
@@ -1,0 +1,5 @@
+---
+"test-durable-function": patch
+---
+
+fix: package name for test-durable-function

--- a/apps/test-durable-function/package.json
+++ b/apps/test-durable-function/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-durable",
+  "name": "test-durable-function",
   "version": "1.0.0",
   "type": "module",
   "description": "Azure Function to test TF module for Durable Functions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8697,9 +8697,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-durable@workspace:apps/test-durable-function":
+"test-durable-function@workspace:apps/test-durable-function":
   version: 0.0.0-use.local
-  resolution: "test-durable@workspace:apps/test-durable-function"
+  resolution: "test-durable-function@workspace:apps/test-durable-function"
   dependencies:
     "@azure/functions": "npm:^4.6.0"
     "@azure/identity": "npm:^4.5.0"


### PR DESCRIPTION
Update the package name in the package.json file to reflect the correct naming convention.