### PR TITLE
Ignore test files during compilation

### DIFF
--- a/.changeset/fluffy-wasps-collect.md
+++ b/.changeset/fluffy-wasps-collect.md
@@ -1,0 +1,5 @@
+---
+"to-do-api": patch
+---
+
+Ignore test files during compilation

--- a/apps/to-do-api/package.json
+++ b/apps/to-do-api/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Azure Function REST API for To Do List",
   "license": "MIT",
-  "main": "./dist/src/main.js",
+  "main": "./dist/main.js",
   "scripts": {
     "clean": "shx rm -rf ./dist",
     "build": "tsc",

--- a/apps/to-do-api/tsconfig.json
+++ b/apps/to-do-api/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "@pagopa/typescript-config-node/tsconfig.json",
   "exclude": [
-    "dist"
+    "dist",
+    "**/__tests__/",
+    "vitest.config.ts"
   ],
   "compilerOptions": {
     "outDir": "dist",


### PR DESCRIPTION
Ignore useless files during compilation.

This will grant the compiled folder to be flat so that we can reference the entry point with `dist/main.js`.