### PR TITLE
Remove unused storageProvider configuration from host.json

### DIFF
--- a/apps/test-durable-function/host.json
+++ b/apps/test-durable-function/host.json
@@ -11,10 +11,6 @@
   },
   "extensions": {
     "durableTask": {
-      "storageProvider": {
-        "connectionStringName": "DfStorageConnectionName"
-      },
-      "hubName": "%SLOT_TASK_HUBNAME%",
       "useGracefulShutdown": true
     }
   }


### PR DESCRIPTION
Eliminate the unused `storageProvider` configuration from the `host.json` file to streamline the code.