### PR TITLE
Upgrade Terraform Azure provider

### DIFF
--- a/.changeset/early-chairs-suffer.md
+++ b/.changeset/early-chairs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": minor
+---
+
+Upgrade Terraform Azure provider

--- a/infra/resources/dev/.terraform.lock.hcl
+++ b/infra/resources/dev/.terraform.lock.hcl
@@ -2,24 +2,21 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.116.0"
-  constraints = ">= 3.100.0, >= 3.111.0, <= 3.116.0"
+  version     = "4.21.1"
+  constraints = ">= 3.100.0, >= 3.110.0, >= 3.111.0, ~> 4.1, < 5.0.0"
   hashes = [
-    "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
-    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
-    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
-    "h1:jwwbQ09fH1RdcNsknt1AkvfSUbULsl7nZQn6S8fabFI=",
-    "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
-    "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
-    "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
-    "zh:59e3ebde1a2e1e094c671e179f231ead60684390dbf02d2b1b7fe67a228daa1a",
-    "zh:5f1f5c7d09efa2ee8ddf21bd9efbbf8286f6e90047556bef305c062fa0ac5880",
-    "zh:a40646aee3c9907276dab926e6123a8d70b1e56174836d4c59a9992034f88d70",
-    "zh:c21d40461bc5836cf56ad3d93d2fc47f61138574a55e972ad5ff1cb73bab66dc",
-    "zh:c56fb91a5ae66153ba0f737a26da1b3d4f88fdef7d41c63e06c5772d93b26953",
-    "zh:d1e60e85f51d12fc150aeab8e31d3f18f859c32f927f99deb5b74cb1e10087aa",
-    "zh:ed35e727e7d79e687cd3d148f52b442961ede286e7c5b4da1dcd9f0128009466",
+    "h1:aPmO4LCXfcwfLhUOIHZpchLabfFFhu+R/taj29aHMK0=",
+    "zh:0ba8a63b1b2572a8b04c122fd76fdca9a529b4ca3364cc1c8883341300285bf8",
+    "zh:1ba2e24a88aa54a87bde2c0519e3bf39a245c6ec1759fd671e96342b0bedc6c7",
+    "zh:22664d3bcad2c9ebecfb1165b076d2733c8a369a0f6d2b7f8f8ad2ee7eb64f03",
+    "zh:32128a565a615386e9020694d8ae9741ae6159ae46eaf0bfbd91b4fa45791af0",
+    "zh:33e7afa34ff2b0936abcad831e0971de58f9ac0debc024033dedcd9d01b5a1db",
+    "zh:540b27a9860d8a027dd1bc88bbf7a7b296e9476ff9f837fc0e48ff7e8a05d110",
+    "zh:6f8462409ab025182844b88b0c3c3b5368e06677a7e44f4edbcc473cd3cd873e",
+    "zh:7ab962e4d8401f0016199e97f7ca48cb9e9ee9e74a548579175ac1e6cd5c6189",
+    "zh:7b8f98dc6e26c9e5395ac1246c3876c1327d8e47b9894b3c8650a0f7b67bbc06",
+    "zh:8c40a9ec1b1f43cd60e6758316b7d2cb08bd2fa87260a37031de1156aa9c2a83",
+    "zh:c4908c33c404050528e0c0bd4d0567d139ddeb0f6f37f61a3c9c8c4e1af2fe2a",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f6d2a4e7c58f44e7d04a4a9c73f35ed452f412c97c85def68c4b52814cbe03ab",
   ]
 }

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -26,7 +26,7 @@
 | <a name="module_func_api_role"></a> [func\_api\_role](#module\_func\_api\_role) | pagopa/dx-azure-role-assignments/azurerm | ~> 0.1 |
 | <a name="module_function_app"></a> [function\_app](#module\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | main |
 | <a name="module_function_test_durable"></a> [function\_test\_durable](#module\_function\_test\_durable) | pagopa/dx-azure-function-app/azurerm | ~> 0.2 |
-| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | github.com/pagopa/dx//infra/modules/azure_naming_convention | main |
+| <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa/dx-azure-naming-convention/azurerm | 0.0.5 |
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 
 ## Resources

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -5,20 +5,20 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.116.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.116.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.21.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_apim"></a> [apim](#module\_apim) | pagopa/dx-azure-api-management/azurerm | ~> 0 |
-| <a name="module_apim_roles"></a> [apim\_roles](#module\_apim\_roles) | pagopa/dx-azure-role-assignments/azurerm | 0.1.0 |
+| <a name="module_apim_roles"></a> [apim\_roles](#module\_apim\_roles) | pagopa/dx-azure-role-assignments/azurerm | ~> 0.1 |
 | <a name="module_app_service"></a> [app\_service](#module\_app\_service) | github.com/pagopa/dx//infra/modules/azure_app_service | main |
 | <a name="module_app_service_roles"></a> [app\_service\_roles](#module\_app\_service\_roles) | pagopa/dx-azure-role-assignments/azurerm | ~> 0.1 |
 | <a name="module_application_insights"></a> [application\_insights](#module\_application\_insights) | ../_modules/application_insights | n/a |

--- a/infra/resources/dev/apim.tf
+++ b/infra/resources/dev/apim.tf
@@ -30,7 +30,7 @@ module "apim" {
 
 module "apim_roles" {
   source       = "pagopa/dx-azure-role-assignments/azurerm"
-  version      = "0.1.0"
+  version      = "~> 0.1"
   principal_id = module.apim.principal_id
 
   key_vault = [

--- a/infra/resources/dev/cosmos.tf
+++ b/infra/resources/dev/cosmos.tf
@@ -34,6 +34,6 @@ resource "azurerm_cosmosdb_sql_container" "tasks" {
   database_name         = azurerm_cosmosdb_sql_database.db.name
   name                  = "tasks"
   resource_group_name   = module.cosmos.resource_group_name
-  partition_key_path    = "/id"
+  partition_key_paths   = ["/id"]
   partition_key_version = "2"
 }

--- a/infra/resources/dev/main.tf
+++ b/infra/resources/dev/main.tf
@@ -21,6 +21,8 @@ provider "azurerm" {
 }
 
 module "naming_convention" {
-  source      = "github.com/pagopa/dx//infra/modules/azure_naming_convention?ref=main"
+  source  = "pagopa/dx-azure-naming-convention/azurerm"
+  version = "0.0.5"
+
   environment = merge(local.environment, { app_name = "pg" })
 }

--- a/infra/resources/dev/main.tf
+++ b/infra/resources/dev/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "<= 3.116.0"
+      version = "~> 4.1"
     }
   }
 

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -8,5 +8,6 @@
   "func_api_role": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "function_test_durable.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
   "function_test_durable": "35993f0f57f017a544522dac18c8b585d9642d93edf9a45d7651a8388ed8980b",
-  "apim": "668b9b729d1d0ba5a074daf93b3ce4a19b1a3b8df668db2be8676ced14b33bf6"
+  "apim": "668b9b729d1d0ba5a074daf93b3ce4a19b1a3b8df668db2be8676ced14b33bf6",
+  "naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4"
 }

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -3,7 +3,7 @@
   "app_service.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
   "cosmos.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
   "function_app.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-  "apim_roles": "286469e8fb2a96ed28912a0def0115207e20ff9f2ab2c16d751dcf2fd97a543a",
+  "apim_roles": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "app_service_roles": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "func_api_role": "52ca57b72bdf639846a472014cb2113d519bdc00dc4a642e925b97ad6b99d25c",
   "function_test_durable.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",


### PR DESCRIPTION
In order to use the `connection_string` to connect the API management to Application Insights we need to use the Azure Provider version `> 4.1`

Closes #CES-822