### PR TITLE
Upgrade APIM to latest major

### DIFF
--- a/.changeset/twenty-flowers-flash.md
+++ b/.changeset/twenty-flowers-flash.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+Upgrade API Management module to the latest major version

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -19,7 +19,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apim"></a> [apim](#module\_apim) | pagopa-dx/azure-api-management/azurerm | ~> 1.2 |
+| <a name="module_apim"></a> [apim](#module\_apim) | pagopa-dx/azure-api-management/azurerm | ~> 2.1 |
 | <a name="module_apim_roles"></a> [apim\_roles](#module\_apim\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1 |
 | <a name="module_app_service_roles"></a> [app\_service\_roles](#module\_app\_service\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.2 |
 | <a name="module_azure_function_v3_application_insights"></a> [azure\_function\_v3\_application\_insights](#module\_azure\_function\_v3\_application\_insights) | ../_modules/application_insights | n/a |

--- a/infra/resources/dev/apim.tf
+++ b/infra/resources/dev/apim.tf
@@ -7,11 +7,11 @@ resource "azurerm_subnet" "apim" {
 
 module "apim" {
   source  = "pagopa-dx/azure-api-management/azurerm"
-  version = "~> 1.2"
+  version = "~> 2.1"
 
   environment         = merge(local.environment, { app_name = "pg" })
   resource_group_name = local.resource_group_name
-  tier                = "s"
+  use_case            = "development"
 
   publisher_email = "playground@pagopa.it"
   publisher_name  = "Playground Publisher"

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "apim": {
-    "hash": "7c4ede49c7e6ebd45b656abca088b846d0e417d3e8e9b700464c7acaefbe5d04",
-    "version": "1.2.2",
+    "hash": "e0738a64be09de854b56326f3b1301aa821bdeb165a1063eff40f52356f8d048",
+    "version": "2.1.0",
     "name": "azure_api_management",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/1.2.2"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-api-management/azurerm/2.1.0"
   },
   "apim_roles": {
     "hash": "a9a9a967e4d17992cf757c66d248bab4413bde68057322486cb0c210b1776326",


### PR DESCRIPTION
This pull request upgrades the Azure API Management (APIM) module to the latest major version across the infrastructure codebase. The update involves changing the module version from 1.2 to 2.1 and updating related configuration to align with the new version's requirements.

Closes CES-1604