### PR TITLE
Upgrade Function App module

### DIFF
--- a/.changeset/humble-icons-joke.md
+++ b/.changeset/humble-icons-joke.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+Upgrade Function App module to latest major version

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -27,7 +27,7 @@
 | <a name="module_azure_function_v3_function_app"></a> [azure\_function\_v3\_function\_app](#module\_azure\_function\_v3\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 0.3 |
 | <a name="module_cosmos"></a> [cosmos](#module\_cosmos) | pagopa-dx/azure-cosmos-account/azurerm | ~> 0.3 |
 | <a name="module_func_api_role"></a> [func\_api\_role](#module\_func\_api\_role) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
-| <a name="module_function_app"></a> [function\_app](#module\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 0.3 |
+| <a name="module_function_app"></a> [function\_app](#module\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
 | <a name="module_function_test_durable"></a> [function\_test\_durable](#module\_function\_test\_durable) | pagopa-dx/azure-function-app/azurerm | ~> 0.2 |
 | <a name="module_function_v3_api_role"></a> [function\_v3\_api\_role](#module\_function\_v3\_api\_role) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -27,7 +27,6 @@
 | <a name="module_azure_function_v3_function_app"></a> [azure\_function\_v3\_function\_app](#module\_azure\_function\_v3\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 0.3 |
 | <a name="module_cosmos"></a> [cosmos](#module\_cosmos) | pagopa-dx/azure-cosmos-account/azurerm | ~> 0.3 |
 | <a name="module_func_api_role"></a> [func\_api\_role](#module\_func\_api\_role) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
-| <a name="module_function_app"></a> [function\_app](#module\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
 | <a name="module_function_test_durable"></a> [function\_test\_durable](#module\_function\_test\_durable) | pagopa-dx/azure-function-app/azurerm | ~> 0.2 |
 | <a name="module_function_v3_api_role"></a> [function\_v3\_api\_role](#module\_function\_v3\_api\_role) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
@@ -35,6 +34,7 @@
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
 | <a name="module_to_do_api_v3"></a> [to\_do\_api\_v3](#module\_to\_do\_api\_v3) | ../_modules/api | n/a |
+| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
 
 ## Resources
 
@@ -47,6 +47,7 @@
 | [azurerm_subnet.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [dx_available_subnet_cidr.function_v3_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [dx_available_subnet_cidr.next_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
+| [dx_available_subnet_cidr.todo_api_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [azurerm_key_vault.common_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.apim_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.to_do_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/infra/resources/dev/apim.tf
+++ b/infra/resources/dev/apim.tf
@@ -86,8 +86,8 @@ module "to_do_api" {
 
   backend = {
     name               = "to-do-api-azure-function"
-    url                = "https://${module.function_app.function_app.function_app.default_hostname}"
-    target_resource_id = module.function_app.function_app.function_app.id
+    url                = "https://${module.todo_api_function_app.function_app.function_app.default_hostname}"
+    target_resource_id = module.todo_api_function_app.function_app.function_app.id
   }
 }
 

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -23,6 +23,8 @@ module "function_app" {
   source  = "pagopa-dx/azure-function-app/azurerm"
   version = "~> 4.1"
 
+  size = "P1v3"
+
   environment         = merge(local.environment, { app_name = "be" })
   resource_group_name = local.resource_group_name
 

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -28,8 +28,6 @@ module "todo_api_function_app" {
   source  = "pagopa-dx/azure-function-app/azurerm"
   version = "~> 4.1"
 
-  size = "P1v3"
-
   environment         = merge(local.environment, { app_name = "be" })
   resource_group_name = local.resource_group_name
 

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -21,10 +21,9 @@ locals {
 
 module "function_app" {
   source  = "pagopa-dx/azure-function-app/azurerm"
-  version = "~> 0.3"
+  version = "~> 4.1"
 
   environment         = merge(local.environment, { app_name = "be" })
-  tier                = "s"
   resource_group_name = local.resource_group_name
 
   virtual_network = {

--- a/infra/resources/dev/locals.tf
+++ b/infra/resources/dev/locals.tf
@@ -26,12 +26,4 @@ locals {
     instance_number = tonumber(local.environment.instance_number)
   })
 
-  # Update with the resources you want to monitor with Dynatrace
-  targets = {
-    cosmos-account = module.cosmos.id
-    app-service    = module.app_service.app_service.app_service.id
-    function-app   = module.function_app.function_app.function_app.id
-    apim           = module.apim.id
-  }
-
 }

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -41,12 +41,6 @@
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.0"
   },
-  "function_app": {
-    "hash": "7f7683c1baaa380df0ef3eb5b3329d4c587cd716e57f268d81ac8b6a7519e641",
-    "version": "4.1.1",
-    "name": "azure_function_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.1.1"
-  },
   "function_test_durable": {
     "hash": "367548c5df2a42f5273583c0de4181c865bd419a4d0aca3cffa2ba19a90c210a",
     "version": "0.3.1",
@@ -70,5 +64,11 @@
     "version": "2.0.1",
     "name": "azure_app_service",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-app-service/azurerm/2.0.1"
+  },
+  "todo_api_function_app": {
+    "hash": "7f7683c1baaa380df0ef3eb5b3329d4c587cd716e57f268d81ac8b6a7519e641",
+    "version": "4.1.1",
+    "name": "azure_function_app",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.1.1"
   }
 }

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -42,10 +42,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.0"
   },
   "function_app": {
-    "hash": "367548c5df2a42f5273583c0de4181c865bd419a4d0aca3cffa2ba19a90c210a",
-    "version": "0.3.1",
+    "hash": "7f7683c1baaa380df0ef3eb5b3329d4c587cd716e57f268d81ac8b6a7519e641",
+    "version": "4.1.1",
     "name": "azure_function_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/0.3.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.1.1"
   },
   "function_test_durable": {
     "hash": "367548c5df2a42f5273583c0de4181c865bd419a4d0aca3cffa2ba19a90c210a",


### PR DESCRIPTION
This pull request updates the `function_app` Terraform module to use a newer version (`~> 4.1`), replacing the previous version (`~> 0.3`). This change ensures that the infrastructure uses the latest features and fixes from the module. The update is reflected across the configuration, documentation, and lock file.

Closes CES-1605