### PR TITLE
Try function app with new entra_id_authentication block

### DIFF
--- a/.changeset/chatty-humans-dress.md
+++ b/.changeset/chatty-humans-dress.md
@@ -1,0 +1,5 @@
+---
+"@infra/resources": patch
+---
+
+Enable Managed Identity authentication on Function Apps

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -29,8 +29,8 @@
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
 | <a name="module_to_do_api_entra_auth"></a> [to\_do\_api\_entra\_auth](#module\_to\_do\_api\_entra\_auth) | ../_modules/api | n/a |
-| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | features/enable-managed-identity-auth-function-app |
-| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | features/enable-managed-identity-auth-function-app |
+| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | e51354899ea6bd299a581993587ac4c17a7a5c3d |
+| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | e51354899ea6bd299a581993587ac4c17a7a5c3d |
 | <a name="module_todo_api_function_app_entra_auth_roles"></a> [todo\_api\_function\_app\_entra\_auth\_roles](#module\_todo\_api\_function\_app\_entra\_auth\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_api_function_app_roles"></a> [todo\_api\_function\_app\_roles](#module\_todo\_api\_function\_app\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_webapp_app_service"></a> [todo\_webapp\_app\_service](#module\_todo\_webapp\_app\_service) | pagopa-dx/azure-app-service/azurerm | ~> 2.0 |

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -29,8 +29,8 @@
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
 | <a name="module_to_do_api_entra_auth"></a> [to\_do\_api\_entra\_auth](#module\_to\_do\_api\_entra\_auth) | ../_modules/api | n/a |
-| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | e51354899ea6bd299a581993587ac4c17a7a5c3d |
-| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | e51354899ea6bd299a581993587ac4c17a7a5c3d |
+| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | f5d5b54a95af2de6d2d09c88cd383f4d91138dec |
+| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | f5d5b54a95af2de6d2d09c88cd383f4d91138dec |
 | <a name="module_todo_api_function_app_entra_auth_roles"></a> [todo\_api\_function\_app\_entra\_auth\_roles](#module\_todo\_api\_function\_app\_entra\_auth\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_api_function_app_roles"></a> [todo\_api\_function\_app\_roles](#module\_todo\_api\_function\_app\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_webapp_app_service"></a> [todo\_webapp\_app\_service](#module\_todo\_webapp\_app\_service) | pagopa-dx/azure-app-service/azurerm | ~> 2.0 |

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -14,7 +14,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.7.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.59.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.60.0 |
 | <a name="provider_dx"></a> [dx](#provider\_dx) | ~> 0 |
 
 ## Modules
@@ -29,8 +29,8 @@
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
 | <a name="module_to_do_api_entra_auth"></a> [to\_do\_api\_entra\_auth](#module\_to\_do\_api\_entra\_auth) | ../_modules/api | n/a |
-| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | f5d5b54a95af2de6d2d09c88cd383f4d91138dec |
-| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | f5d5b54a95af2de6d2d09c88cd383f4d91138dec |
+| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
+| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
 | <a name="module_todo_api_function_app_entra_auth_roles"></a> [todo\_api\_function\_app\_entra\_auth\_roles](#module\_todo\_api\_function\_app\_entra\_auth\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_api_function_app_roles"></a> [todo\_api\_function\_app\_roles](#module\_todo\_api\_function\_app\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_webapp_app_service"></a> [todo\_webapp\_app\_service](#module\_todo\_webapp\_app\_service) | pagopa-dx/azure-app-service/azurerm | ~> 2.0 |

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -29,8 +29,8 @@
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
 | <a name="module_to_do_api_entra_auth"></a> [to\_do\_api\_entra\_auth](#module\_to\_do\_api\_entra\_auth) | ../_modules/api | n/a |
-| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
-| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | bb7e24d72a1cdd2a81c061b9a81ecdb06d23daa9 |
+| <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | github.com/pagopa/dx//infra/modules/azure_function_app | features/enable-managed-identity-auth-function-app |
+| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | features/enable-managed-identity-auth-function-app |
 | <a name="module_todo_api_function_app_entra_auth_roles"></a> [todo\_api\_function\_app\_entra\_auth\_roles](#module\_todo\_api\_function\_app\_entra\_auth\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_api_function_app_roles"></a> [todo\_api\_function\_app\_roles](#module\_todo\_api\_function\_app\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_webapp_app_service"></a> [todo\_webapp\_app\_service](#module\_todo\_webapp\_app\_service) | pagopa-dx/azure-app-service/azurerm | ~> 2.0 |

--- a/infra/resources/dev/README.md
+++ b/infra/resources/dev/README.md
@@ -5,6 +5,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.1 |
 | <a name="requirement_dx"></a> [dx](#requirement\_dx) | ~> 0 |
 
@@ -12,7 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.60.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.7.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.59.0 |
 | <a name="provider_dx"></a> [dx](#provider\_dx) | ~> 0 |
 
 ## Modules
@@ -26,7 +28,10 @@
 | <a name="module_naming_convention"></a> [naming\_convention](#module\_naming\_convention) | pagopa-dx/azure-naming-convention/azurerm | ~> 0.0 |
 | <a name="module_to_do_api"></a> [to\_do\_api](#module\_to\_do\_api) | ../_modules/api | n/a |
 | <a name="module_to_do_api_application_insights"></a> [to\_do\_api\_application\_insights](#module\_to\_do\_api\_application\_insights) | ../_modules/application_insights | n/a |
+| <a name="module_to_do_api_entra_auth"></a> [to\_do\_api\_entra\_auth](#module\_to\_do\_api\_entra\_auth) | ../_modules/api | n/a |
 | <a name="module_todo_api_function_app"></a> [todo\_api\_function\_app](#module\_todo\_api\_function\_app) | pagopa-dx/azure-function-app/azurerm | ~> 4.1 |
+| <a name="module_todo_api_function_app_entra_auth"></a> [todo\_api\_function\_app\_entra\_auth](#module\_todo\_api\_function\_app\_entra\_auth) | github.com/pagopa/dx//infra/modules/azure_function_app | bb7e24d72a1cdd2a81c061b9a81ecdb06d23daa9 |
+| <a name="module_todo_api_function_app_entra_auth_roles"></a> [todo\_api\_function\_app\_entra\_auth\_roles](#module\_todo\_api\_function\_app\_entra\_auth\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_api_function_app_roles"></a> [todo\_api\_function\_app\_roles](#module\_todo\_api\_function\_app\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.0 |
 | <a name="module_todo_webapp_app_service"></a> [todo\_webapp\_app\_service](#module\_todo\_webapp\_app\_service) | pagopa-dx/azure-app-service/azurerm | ~> 2.0 |
 | <a name="module_todo_webapp_roles"></a> [todo\_webapp\_roles](#module\_todo\_webapp\_roles) | pagopa-dx/azure-role-assignments/azurerm | ~> 1.2 |
@@ -42,6 +47,9 @@
 | [dx_available_subnet_cidr.function_v3_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [dx_available_subnet_cidr.next_todo_webapp_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
 | [dx_available_subnet_cidr.todo_api_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
+| [dx_available_subnet_cidr.todo_api_entra_auth_cidr](https://registry.terraform.io/providers/pagopa-dx/azure/latest/docs/resources/available_subnet_cidr) | resource |
+| [azuread_application.entra_auth_app](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application) | data source |
+| [azuread_service_principal.apim](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_key_vault.common_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.common_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.net_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/infra/resources/dev/apim.tf
+++ b/infra/resources/dev/apim.tf
@@ -73,3 +73,26 @@ module "to_do_api" {
     target_resource_id = module.todo_api_function_app.function_app.function_app.id
   }
 }
+# To Do API - Without x-funcions-key header
+module "to_do_api_entra_auth" {
+  source = "../_modules/api"
+
+  entra_id_app_client_id = module.todo_api_function_app_entra_auth.entra_id_authentication.entra_application_client_id
+
+  api = {
+    name         = "to-do-api-entra"
+    display_name = "To Do API - Entra Auth"
+    description  = "API to handle a To Do list"
+    path         = "auth"
+    openapi      = file("${path.module}/../../../apps/to-do-api/docs/openapi.yaml")
+  }
+
+  apim_name           = module.apim.name
+  resource_group_name = module.apim.resource_group_name
+
+  backend = {
+    name               = "to-do-api-azure-function-entra-auth"
+    url                = "https://${module.todo_api_function_app_entra_auth.function_app.function_app.default_hostname}/api"
+    target_resource_id = module.todo_api_function_app_entra_auth.function_app.function_app.id
+  }
+}

--- a/infra/resources/dev/apim.tf
+++ b/infra/resources/dev/apim.tf
@@ -77,7 +77,7 @@ module "to_do_api" {
 module "to_do_api_entra_auth" {
   source = "../_modules/api"
 
-  entra_id_app_client_id = module.todo_api_function_app_entra_auth.entra_id_authentication.entra_application_client_id
+  entra_id_app_client_id = module.todo_api_function_app_entra_auth.entra_id_authentication.audience_client_id
 
   api = {
     name         = "to-do-api-entra"

--- a/infra/resources/dev/data.tf
+++ b/infra/resources/dev/data.tf
@@ -21,3 +21,13 @@ data "azurerm_key_vault" "common_kv" {
   name                = "${module.naming_convention.project}-common-kv-${local.environment.instance_number}"
   resource_group_name = data.azurerm_resource_group.common_rg.name
 }
+
+# Entra ID application used as identity provider for Function App authentication.
+# Callers (e.g. APIM) use their Managed Identity to obtain a JWT from this app.
+data "azuread_application" "entra_auth_app" {
+  display_name = "playground-test-apim-auth"
+}
+
+data "azuread_service_principal" "apim" {
+  display_name = module.apim.name
+}

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -25,7 +25,7 @@ resource "dx_available_subnet_cidr" "todo_api_cidr" {
 }
 
 module "todo_api_function_app" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=e51354899ea6bd299a581993587ac4c17a7a5c3d"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=f5d5b54a95af2de6d2d09c88cd383f4d91138dec"
   # version = "~> 4.1"
 
   node_version        = 22
@@ -148,7 +148,7 @@ resource "dx_available_subnet_cidr" "todo_api_entra_auth_cidr" {
 }
 
 module "todo_api_function_app_entra_auth" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=e51354899ea6bd299a581993587ac4c17a7a5c3d"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=f5d5b54a95af2de6d2d09c88cd383f4d91138dec"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "id" })

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -25,8 +25,8 @@ resource "dx_available_subnet_cidr" "todo_api_cidr" {
 }
 
 module "todo_api_function_app" {
-  source  = "pagopa-dx/azure-function-app/azurerm"
-  version = "~> 4.1"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=features/enable-managed-identity-auth-function-app"
+  # version = "~> 4.1"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "be" })
@@ -148,7 +148,7 @@ resource "dx_available_subnet_cidr" "todo_api_entra_auth_cidr" {
 }
 
 module "todo_api_function_app_entra_auth" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=bb7e24d72a1cdd2a81c061b9a81ecdb06d23daa9"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=features/enable-managed-identity-auth-function-app"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "id" })

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -25,7 +25,7 @@ resource "dx_available_subnet_cidr" "todo_api_cidr" {
 }
 
 module "todo_api_function_app" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=features/enable-managed-identity-auth-function-app"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=e51354899ea6bd299a581993587ac4c17a7a5c3d"
   # version = "~> 4.1"
 
   node_version        = 22
@@ -148,7 +148,7 @@ resource "dx_available_subnet_cidr" "todo_api_entra_auth_cidr" {
 }
 
 module "todo_api_function_app_entra_auth" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=features/enable-managed-identity-auth-function-app"
+  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=e51354899ea6bd299a581993587ac4c17a7a5c3d"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "id" })
@@ -171,8 +171,8 @@ module "todo_api_function_app_entra_auth" {
   application_insights_sampling_percentage = 100
 
   entra_id_authentication = {
-    entra_application_client_id = data.azuread_application.entra_auth_app.client_id
-    allowed_client_applications = [
+    audience_client_id = data.azuread_application.entra_auth_app.client_id
+    allowed_callers_client_ids = [
       data.azuread_service_principal.apim.client_id
     ]
     tenant_id = data.azurerm_subscription.current.tenant_id

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -151,7 +151,7 @@ module "todo_api_function_app_entra_auth" {
   source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=bb7e24d72a1cdd2a81c061b9a81ecdb06d23daa9"
 
   node_version        = 22
-  environment         = merge(local.environment, { app_name = "ea" })
+  environment         = merge(local.environment, { app_name = "id" })
   resource_group_name = local.resource_group_name
 
   virtual_network = {

--- a/infra/resources/dev/function_app.tf
+++ b/infra/resources/dev/function_app.tf
@@ -25,8 +25,8 @@ resource "dx_available_subnet_cidr" "todo_api_cidr" {
 }
 
 module "todo_api_function_app" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=f5d5b54a95af2de6d2d09c88cd383f4d91138dec"
-  # version = "~> 4.1"
+  source  = "pagopa-dx/azure-function-app/azurerm"
+  version = "~> 4.1"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "be" })
@@ -148,7 +148,8 @@ resource "dx_available_subnet_cidr" "todo_api_entra_auth_cidr" {
 }
 
 module "todo_api_function_app_entra_auth" {
-  source = "github.com/pagopa/dx//infra/modules/azure_function_app?ref=f5d5b54a95af2de6d2d09c88cd383f4d91138dec"
+  source  = "pagopa-dx/azure-function-app/azurerm"
+  version = "~> 4.1"
 
   node_version        = 22
   environment         = merge(local.environment, { app_name = "id" })

--- a/infra/resources/dev/main.tf
+++ b/infra/resources/dev/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.1"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
     dx = {
       source  = "pagopa-dx/azure"
       version = "~> 0"

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -12,10 +12,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-cosmos-account/azurerm/0.4.0"
   },
   "function_v3_function_app": {
-    "hash": "0ebbe863c7b48075ef6a3a79465fd2905aca43e043065a4e8d07dd90d28499dd",
-    "version": "4.2.1",
+    "hash": "0896695540ef03c38ad57186a72589ffd6bca2e658bebfc05040bd44bd26897f",
+    "version": "4.3.0",
     "name": "azure_function_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.2.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.3.0"
   },
   "function_v3_function_app_roles": {
     "hash": "320e6d020c54d3d5094ea8aaa6440621cde729ec1f61ce1baf1b79f0732430da",
@@ -52,5 +52,17 @@
     "version": "1.3.1",
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.1"
+  },
+  "todo_api_function_app": {
+    "hash": "0896695540ef03c38ad57186a72589ffd6bca2e658bebfc05040bd44bd26897f",
+    "version": "4.3.0",
+    "name": "azure_function_app",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.3.0"
+  },
+  "todo_api_function_app_entra_auth": {
+    "hash": "0896695540ef03c38ad57186a72589ffd6bca2e658bebfc05040bd44bd26897f",
+    "version": "4.3.0",
+    "name": "azure_function_app",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.3.0"
   }
 }

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -29,12 +29,6 @@
     "name": "azure_naming_convention",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-naming-convention/azurerm/0.0.8"
   },
-  "todo_api_function_app": {
-    "hash": "0ebbe863c7b48075ef6a3a79465fd2905aca43e043065a4e8d07dd90d28499dd",
-    "version": "4.2.1",
-    "name": "azure_function_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.2.1"
-  },
   "todo_api_function_app_roles": {
     "hash": "320e6d020c54d3d5094ea8aaa6440621cde729ec1f61ce1baf1b79f0732430da",
     "version": "1.3.1",

--- a/infra/resources/dev/tfmodules.lock.json
+++ b/infra/resources/dev/tfmodules.lock.json
@@ -52,5 +52,11 @@
     "version": "1.3.1",
     "name": "azure_role_assignments",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.1"
+  },
+  "todo_api_function_app_entra_auth_roles": {
+    "hash": "320e6d020c54d3d5094ea8aaa6440621cde729ec1f61ce1baf1b79f0732430da",
+    "version": "1.3.1",
+    "name": "azure_role_assignments",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-role-assignments/azurerm/1.3.1"
   }
 }


### PR DESCRIPTION
This pull request introduces Entra ID authentication support for the To Do API in the development environment. It adds new infrastructure modules and resources to deploy a second Azure Function App configured for Entra ID (formerly Azure AD) authentication, updates provider dependencies, and enhances documentation to reflect these changes.

**Entra ID Authentication Integration:**

* Added a new Azure Function App (`todo_api_function_app_entra_auth`) configured for Entra ID authentication, including subnet allocation, application settings, and role assignments for Cosmos DB and Key Vault access.
* Introduced a new API Management module (`to_do_api_entra_auth`) that exposes the To Do API without requiring the `x-functions-key` header, leveraging Entra ID authentication.

Closes CES-1687 CES-1688