### PR TITLE
Potential fix for code scanning alert no. 152: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/enrich_pr.yaml
+++ b/.github/workflows/enrich_pr.yaml
@@ -7,6 +7,9 @@ jobs:
 
   add_assignee:
     name: Add assignee
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/pagopa/dx-playground/security/code-scanning/152](https://github.com/pagopa/dx-playground/security/code-scanning/152)

Add an explicit `permissions` block to the `add_assignee` job in `.github/workflows/enrich_pr.yaml` so the `GITHUB_TOKEN` is scoped to only what this job needs.  
For auto-assigning PR assignees, the minimal required scope is typically:

- `contents: read` (safe baseline for reading repo metadata/config)
- `pull-requests: write` (required to modify PR assignees)

Best single change without altering behavior: insert this permissions block directly under `name` (or before `runs-on`) in `jobs.add_assignee`, mirroring the style already used in `add_labels`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
